### PR TITLE
#23 NoMap, NoDestionation 対応

### DIFF
--- a/src/KeyMapSync/Synchronizer.cs
+++ b/src/KeyMapSync/Synchronizer.cs
@@ -109,8 +109,16 @@ namespace KeyMapSync
 
             var versionNo = DbExecutor.InsertVersionTableOrDefault(def);
 
-            var n = DbExecutor.InsertDestinationTable(def);
-            if (count != n) throw new InvalidOperationException($"destinaition-table insert fail.(expect count:{count}, actual:{n}");
+            var n = 0;
+            if (def.DestinationTable == null)
+            {
+                count = 0;
+            }
+            else
+            {
+                n = DbExecutor.InsertDestinationTable(def);
+                if (count != n) throw new InvalidOperationException($"destinaition-table insert fail.(expect count:{count}, actual:{n}");
+            }
 
             if (versionNo.HasValue)
             {

--- a/src/KeyMapSync/_database/DbExecutor.cs
+++ b/src/KeyMapSync/_database/DbExecutor.cs
@@ -132,6 +132,8 @@ namespace KeyMapSync
             var map = def.MappingTable;
             var dst = def.DestinationTable;
 
+            var destIdColumn = (dst?.SequenceColumn == null) ? "" : $"{dst.SequenceColumn.NextValCommand} as { dst.SequenceColumn.ColumnName}, ";
+
             var where = !def.IsNeedExistsCheck ? "" : $"where not exists (select * from {map.TableFullName} x where {dsmap.DatasourceKeyColumns.ToString(" and ", x => $"x.{x} = {dsmap.DatasourceAliasName}.{x}")})";
 
             var sql = @$"
@@ -139,7 +141,7 @@ create temporary table {def.DatasourceTable.TableName}
 as
 {dsmap.DatasourceQueryGenarator(def.Sender)}
 select
-    {dst.SequenceColumn.NextValCommand} as {dst.SequenceColumn.ColumnName}, {dsmap.DatasourceAliasName}.*
+    {destIdColumn}{dsmap.DatasourceAliasName}.*
 from
     {dsmap.DatasourceAliasName}
 {where}
@@ -166,6 +168,7 @@ order by
         public int InsertDestinationTable(SyncMap def)
         {
             var dest = def.DestinationTable;
+            if (dest == null) return 0;
 
             if (def.DatasourceTable.IsMustCreate == false)
             {

--- a/src/KeyMapSync/_database/PostgresDB.cs
+++ b/src/KeyMapSync/_database/PostgresDB.cs
@@ -92,9 +92,14 @@ where
 create table {tableName}
 (
 {sequenceColumnName} serial8 primary key
+, datasource_name text not null
 , mapping_name text not null
 , create_timestamp timestamp not null default current_timestamp
-)"
+)
+;
+create index on {tableName}(datasource_name)
+;
+"
 ;
             return new SqlEventArgs(sql);
         }
@@ -106,7 +111,11 @@ create table {tableName}
 (
 {dest.SequenceColumn.ColumnName} int8 primary key
 , {version.SequenceColumn.ColumnName} int8 not null
-)"
+)
+;
+create index on {tableName}({version.SequenceColumn.ColumnName})
+;
+"
 ;
             return new SqlEventArgs(sql);
         }
@@ -128,8 +137,13 @@ create table {tableName}
         {
             var version = def.VersionTable;
 
-            var sql = $"insert into {version.TableFullName}(mapping_name) values (:mapping_name) returning {version.SequenceColumn.ColumnName};";
-            var prm = new { mapping_name = def.MappingName };
+            var sql = $"insert into {version.TableFullName}(datasource_name, mapping_name) values (:datasource_name, :mapping_name) returning {version.SequenceColumn.ColumnName};";
+
+            var prm = new
+            {
+                datasource_name = (def?.DatasourceName == null) ? "" : def.DatasourceName,
+                mapping_name = (def?.MappingName == null) ? "" : def.MappingName,
+            };
             return new SqlEventArgs(sql, prm);
         }
     }

--- a/src/KeyMapSync/_database/SQLiteDB.cs
+++ b/src/KeyMapSync/_database/SQLiteDB.cs
@@ -53,6 +53,7 @@ select '' as schemaname ,tbl_name as tablename from sqlite_temp_master where typ
 create table {tableName}
 (
 {sequenceColumnName} integer primary key autoincrement
+, datasource_name text not null
 , mapping_name text not null
 , create_timestamp timestamp not null default current_timestamp
 )"
@@ -89,8 +90,12 @@ create table {tableName}
         {
             var version = def.VersionTable;
 
-            var sql = $"insert into {version.TableFullName}(mapping_name) values (:mapping_name); select last_insert_rowid();";
-            var prm = new { mapping_name = def.MappingName };
+            var sql = $"insert into {version.TableFullName}(datasource_name, mapping_name) values (:datasource_name, :mapping_name); select last_insert_rowid();";
+            var prm = new
+            {
+                datasource_name = (def?.DatasourceName == null) ? "" : def.DatasourceName,
+                mapping_name = (def?.MappingName == null) ? "" : def.MappingName,
+            };
             return new SqlEventArgs(sql, prm);
         }
     }

--- a/src/KeyMapSync/_mapping/SyncMap.cs
+++ b/src/KeyMapSync/_mapping/SyncMap.cs
@@ -28,5 +28,7 @@ namespace KeyMapSync
         public bool IsNeedExistsCheck { get; set; } = true;
 
         public IDatasourceMap DatasourceMap { get; set; }
+
+        public string DatasourceName { get; set; }
     }
 }

--- a/tests/KeyMapSync.Test/SyncMapBuilderTest.cs
+++ b/tests/KeyMapSync.Test/SyncMapBuilderTest.cs
@@ -44,7 +44,7 @@ namespace KeyMapSync.Test
 
                 //sync_version
                 Assert.Equal("builder_test_destination_sync_version", def.VersionTable.TableFullName);
-                Assert.Equal("builder_test_destination_sync_version_id,mapping_name,create_timestamp", string.Join(',', def.VersionTable.Columns));
+                Assert.Equal("builder_test_destination_sync_version_id,datasource_name,mapping_name,create_timestamp", string.Join(',', def.VersionTable.Columns));
                 Assert.Equal("builder_test_destination_sync_version_id", def.VersionTable.SequenceColumn.ColumnName);
                 Assert.Equal("row_number() over() + (select max(seq) from (select seq from sqlite_sequence where name = 'builder_test_destination_sync_version' union all select 0))", def.VersionTable.SequenceColumn.NextValCommand);
 


### PR DESCRIPTION
sync_version table に datasource_name 列を追加。データソースクラス名が格納されます。
mapping_name が指定されていなくても動作します。（転送はされます）
destination が指定されていなくてもエラーとしません。（転送はされませんが、テンポラリだけは作成される）
Testクラスの成否が実行順序に依存している問題を修正。（各テスト処理は独立して評価できるものとした）